### PR TITLE
Update PHP runtime and Composer dependencies

### DIFF
--- a/.github/workflows/packagist-bluesky-cron.yml
+++ b/.github/workflows/packagist-bluesky-cron.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           extensions: mbstring, xml, zip, curl
           coverage: none
       

--- a/composer.json
+++ b/composer.json
@@ -14,14 +14,14 @@
         }
     ],
     "require": {
-        "php": "^8.3",
-        "guzzlehttp/guzzle": "^7.9",
-        "symfony/console": "^7.0",
-        "monolog/monolog": "^3.5",
-        "symfony/dotenv": "^7.0"
+        "php": "^8.4",
+        "guzzlehttp/guzzle": "^7.10",
+        "symfony/console": "^7.3",
+        "monolog/monolog": "^3.9",
+        "symfony/dotenv": "^7.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^12.0",
+        "phpunit/phpunit": "^12.4",
         "phpstan/phpstan": "^2.1"
     },
     "scripts": {


### PR DESCRIPTION
- Update PHP requirement from 8.3 to 8.4
- Update guzzlehttp/guzzle from ^7.9 to ^7.10
- Update symfony/console from ^7.0 to ^7.3
- Update symfony/dotenv from ^7.0 to ^7.3
- Update monolog/monolog from ^3.5 to ^3.9
- Update phpunit/phpunit from ^12.0 to ^12.4
- Update GitHub Actions workflow to use PHP 8.4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * PHP ランタイムを 8.3 から 8.4 にアップグレード
  * 複数の依存ライブラリを更新（Guzzle、Symfony Console、Monolog、Symfony Dotenv、PHPUnit）

<!-- end of auto-generated comment: release notes by coderabbit.ai -->